### PR TITLE
fix: handle -1 as valid exception code

### DIFF
--- a/src/links_checker/checker.go
+++ b/src/links_checker/checker.go
@@ -34,7 +34,7 @@ func (c *Checker) Check(link string) (bool, int, []int) {
     expectedCodes = append(expectedCodes, c.expectedCodesList.getList(link)...)
 
     if err != nil {
-        return false, -1, expectedCodes
+        return c.expectedCodesList.has(link, -1),  -1, expectedCodes
     }
 
     defer resp.Body.Close()


### PR DESCRIPTION
What we see in https://github.com/ru-de/faq/pull/666 is that some links might consistently lead to `-1`. If the exception is happening during request, this case is not being handled with `expectedCodes`.

P.S. Please consider this PR as part of [Hacktoberfest](https://hacktoberfest.com/) and, if it's useful, please add `hacktoberfest-accepted` label to the PR. Thanks :)